### PR TITLE
(mostly) support Python3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For example: querying on a non-hash_key in dynamo will run a scan and be slow.
 `endpoint` - specify an endpoint to use a local or non-AWS implementation of
 DynamoDB
 
-### SQLite
+### SQLite (Python 3.7+)
 
 `database` - the filename of the database file for SQLite to use
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,6 +39,7 @@ python-versions = ">=3.6.2"
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.8.1,<1"
 regex = ">=2020.1.8"
@@ -79,7 +80,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (0.11.24)"]
+crt = ["awscrt (==0.11.24)"]
 
 [[package]]
 name = "certifi"
@@ -119,6 +120,14 @@ description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "docker"
@@ -244,6 +253,7 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
@@ -322,7 +332,7 @@ idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
@@ -394,7 +404,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "websocket-client"
@@ -418,8 +428,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "c08aff4754ed15cd1dc6196aebd71412c2273871fc4c70ce44128ff7d075f5a4"
+python-versions = ">=3.6"
+content-hash = "ff157e17c9e8cf405a9ff6573a76abfbe7ca7a5c1616c2fa270abecaa6e96e3c"
 
 [metadata.files]
 appdirs = [
@@ -461,6 +471,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 docker = [
     {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,11 @@ authors = ["Timothy Farrell <tim.farrell@rackspace.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.6"
 rule-engine = "^3.2.0"
 pydantic = "^1.8.2"
 boto3 = {version = "^1.17.112", optional = true}
+dataclasses = {version = "^0.8", python = "3.6"}
 
 [tool.poetry.dev-dependencies]
 boto3 = "^1.17.112"
@@ -23,4 +24,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 100
-target-version = ['py37']
+target-version = ['py36']


### PR DESCRIPTION
Py3.6 does not use _GenericAlias and referencing __annotations__ is bad practice. Switch to the public `get_type_hints` call. Conditionally import the `dataclasses` backport module in 3.6.

There is a known bug in Python3.6 in this version such that SQLite adapter/converter does not properly work with serializing/deserializing containers.