### PR TITLE
Add DynamoDB Backend Index support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
+.vscode
+
+.pytest_cache
 __pycache__
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ For example: querying on a non-hash_key in dynamo will run a scan and be slow.
 `endpoint` - specify an endpoint to use a local or non-AWS implementation of
 DynamoDB
 
+`indexes` - (optional) specify a mapping of index-name to tuple(partition_key). Pass `index_name` to `Model.query()` to use an index.
+
 ### SQLite (Python 3.7+)
 
 `database` - the filename of the database file for SQLite to use

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # PydantiCRUD
+
 Supercharge your Pydantic models with CRUD methods and a pluggable backend
 
-pydanticrud let's you add a few details to your pydantic models to get basic 
+pydanticrud let's you add a few details to your pydantic models to get basic
 CRUD methods automatically built into your models for the backend of your
 choice.
 
 ## Usage
 
 ```python
-from pydanticrud import BaseModel, SqliteBackend
+from pydanticrud import BaseModel, DynamoDbBackend
 
 class User(BaseModel):
     id: int
@@ -16,15 +17,15 @@ class User(BaseModel):
 
     class Config:
         title = 'User'
-        backend = SqliteBackend
+        backend = DynamoDbBackend
         hash_key = 'id'
-        database = ":memory:"
 ```
 
 First, use the `BaseModel` from `pydanticrud` instead of `pydantic`.
 
-Next add your backend to your model's `Config` class. PydantiCRUD provides SQLite
-and DynamoDB backends. You can provide your own if you like.
+Next add your backend to your model's `Config` class. PydantiCRUD is geared
+toward DynamoDB but provides SQLite for lighter-weight usage. You can provide
+your own if you like.
 
 Finally, add appropriate members to the `Config` class for the chosen backend.
 
@@ -59,7 +60,7 @@ For example: querying on a non-hash_key in dynamo will run a scan and be slow.
 
 `region` - (optional) specify the region to access dynamodb in.
 
-`endpoint` - specify an endpoint to use a local or non-AWS implementation of
+`endpoint` - (optional) specify an endpoint to use a local or non-AWS implementation of
 DynamoDB
 
 `indexes` - (optional) specify a mapping of index-name to tuple(partition_key). Pass `index_name` to `Model.query()` to use an index.
@@ -72,8 +73,8 @@ DynamoDB
 
 There is plenty of room for improvement to PydantiCRUD.
 
-- Backend feature support not being consistent is the most egregious flaw that can be incrementally
-improved.
+- Backend feature support not being consistent is the most egregious flaw that
+can be incrementally improved.
 - SQLite JSON1 extension support for more powerful queries.
 - Add more backends
 

--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -114,7 +114,7 @@ class Backend:
         self.table_name = cls.get_table_name()
 
         self.indexes = getattr(cfg, "indexes", {})
-        self.indexes[""] = (self.hash_key, )
+        self.indexes[""] = (self.hash_key,)
 
         self.dynamodb = boto3.resource(
             "dynamodb",
@@ -174,7 +174,8 @@ class Backend:
                     "AttributeType": DYNAMO_TYPE_MAP.get(
                         schema["properties"][key_name].get("type", "anyOf"), "S"
                     ),
-                } for key_name in key_names
+                }
+                for key_name in key_names
             ],
             TableName=self.table_name,
             KeySchema=[
@@ -187,15 +188,13 @@ class Backend:
                     "Projection": {
                         "ProjectionType": "ALL",
                     },
-                    "ProvisionedThroughput": {
-                        "ReadCapacityUnits": 1,
-                        "WriteCapacityUnits": 1
-                    },
-                    "KeySchema": [{
-                        "AttributeName": attr,
-                        "KeyType": ["HASH", "RANGE"][i]
-                    } for i, attr in enumerate(keys)]
-                } for index_name, keys in indexes.items()
+                    "ProvisionedThroughput": {"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
+                    "KeySchema": [
+                        {"AttributeName": attr, "KeyType": ["HASH", "RANGE"][i]}
+                        for i, attr in enumerate(keys)
+                    ],
+                }
+                for index_name, keys in indexes.items()
             ],
         )
         table.wait_until_exists()
@@ -212,14 +211,12 @@ class Backend:
 
     def query(self, expression, index_name: Optional[str] = ""):
         table = self.get_table()
-        possible_keys = self.indexes.get(index_name, (self.hash_key, ))
+        possible_keys = self.indexes.get(index_name, (self.hash_key,))
         expr, keys_used = rule_to_boto_expression(expression, possible_keys)
         if index_name is not None:
             validate_index(self.indexes, index_name, keys_used)
 
-            params = dict(
-                KeyConditionExpression=expr
-            )
+            params = dict(KeyConditionExpression=expr)
             if index_name:
                 params["IndexName"] = index_name
             resp = table.query(**params)

--- a/pydanticrud/backends/sqlite.py
+++ b/pydanticrud/backends/sqlite.py
@@ -31,8 +31,8 @@ class ColumnMetaData:
 
 
 def get_column_data(field_type):
-    if hasattr(field_type, '__origin__'):
-        field_type = getattr(field_type, '__origin__')
+    if hasattr(field_type, "__origin__"):
+        field_type = getattr(field_type, "__origin__")
     python_type_name = field_type.__name__
     sqlite_native = python_type_name.lower() in SQLITE_NATIVE_TYPES
 
@@ -52,8 +52,7 @@ class Backend:
         type_hints = get_type_hints(cls)
         self._columns = tuple(type_hints.keys())
         self._columns = {
-            field_name: get_column_data(field_type)
-            for field_name, field_type in type_hints.items()
+            field_name: get_column_data(field_type) for field_name, field_type in type_hints.items()
         }
         _non_native_column_types = set(
             col.python_type for col in self._columns.values() if not col.sqlite_native

--- a/pydanticrud/main.py
+++ b/pydanticrud/main.py
@@ -26,8 +26,8 @@ class BaseModel(PydanticBaseModel, metaclass=CrudMetaClass):
         return cls.__backend__.exists()
 
     @classmethod
-    def query(cls, condition: Rule):
-        res = cls.__backend__.query(condition)
+    def query(cls, condition: Rule, **kwargs):
+        res = cls.__backend__.query(condition, **kwargs)
         return [cls.parse_obj(i) for i in res]
 
     @classmethod

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -54,7 +54,14 @@ def model_data_generator(**kwargs):
         value=random.randint(0, 100000),
         name=name,
         total=round(random.random(), 9),
-        timestamp=datetime(random.randint(2005, 2021), random.randint(1, 12), 2, 2, 2, 0),
+        timestamp=datetime(
+            random.randint(2005, 2021),
+            random.randint(1, 12),
+            random.randint(1, 28),
+            random.randint(1, 12),
+            random.randint(1, 59),
+            0
+        ),
         sigfig=Decimal(str(random.random())[:8]),
         enabled=random.choice((True, False)),
         data={random.randint(0, 1000): random.randint(0, 1000)},
@@ -135,9 +142,9 @@ def test_query_errors_with_nonprimary_key(dynamo, query_data):
 def test_query_with_indexed_hash_key(dynamo, query_data):
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    res = Model.query(Rule(f"id == {data_by_timestamp[2]['id']}"), index_name="by-id")
+    res = Model.query(Rule(f"id == {data_by_timestamp[0]['id']}"), index_name="by-id")
     res_data = {m.name: m.dict() for m in res}
-    assert res_data == {query_data[0]["name"]: query_data[0]}
+    assert res_data == {data_by_timestamp[0]["name"]: data_by_timestamp[0]}
 
 
 def test_query_scan(dynamo, query_data):

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -135,14 +135,14 @@ def test_query_errors_with_nonprimary_key(dynamo, query_data):
     # Query based on the non-primary key with no index specified
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    with pytest.raises(ConditionCheckFailed, match=r"Index DEFAULT does not use \(\)"):
+    with pytest.raises(ConditionCheckFailed, match=r"No keys in expression. Enable scan or add an index."):
         Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"))
 
 
 def test_query_with_indexed_hash_key(dynamo, query_data):
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    res = Model.query(Rule(f"id == {data_by_timestamp[0]['id']}"), index_name="by-id")
+    res = Model.query(Rule(f"id == {data_by_timestamp[0]['id']}"))
     res_data = {m.name: m.dict() for m in res}
     assert res_data == {data_by_timestamp[0]["name"]: data_by_timestamp[0]}
 
@@ -150,12 +150,12 @@ def test_query_with_indexed_hash_key(dynamo, query_data):
 def test_query_scan(dynamo, query_data):
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    res = Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"), index_name=None)
+    res = Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"), scan=True)
     res_data = {m.name: m.dict() for m in res}
     assert res_data == {d["name"]: d for d in data_by_timestamp[:2]}
 
 
 def test_query_scan_contains(dynamo, query_data):
-    res = Model.query(Rule(f"'{query_data[2]['items'][1]}' in items"), index_name=None)
+    res = Model.query(Rule(f"'{query_data[2]['items'][1]}' in items"), scan=True)
     res_data = {m.name: m.dict() for m in res}
     assert res_data == {query_data[2]["name"]: query_data[2]}

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -34,6 +34,9 @@ class Model(BaseModel):
         hash_key = "name"
         backend = DynamoDbBackend
         endpoint = "http://localhost:18002"
+        indexes = {
+            "by-id": ("id", )
+        }
 
 
 def model_data_generator(**kwargs):
@@ -128,6 +131,11 @@ def test_query(dynamo, query_data):
     with pytest.raises(ConditionCheckFailed, match=r'Index DEFAULT does not use \(\)'):
         Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"))
 
+    # Query based on the non-primary key with index
+    data_by_timestamp = query_data[:]
+    data_by_timestamp.sort(key=lambda d: d["timestamp"])
+    res = Model.query(Rule(f"id == {data_by_timestamp[2]['id']}"), index_name='by-id')
+    
 
 def test_query_scan(dynamo, query_data):
     # Query(Scan) by setting index_name=None

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -116,33 +116,39 @@ def test_save_get_delete(dynamo):
         Model.get(data["name"])
 
 
-def test_query(dynamo, query_data):
+def test_query_with_hash_key(dynamo, query_data):
     # Query based on the hash_key (no index needed)
     res = Model.query(Rule(f"name == '{query_data[0]['name']}'"))
     res_data = {m.name: m.dict() for m in res}
     query_data[0]["data"] = None  # This is a default value and should be populated as such
     assert res_data == {query_data[0]["name"]: query_data[0]}
 
+
+def test_query_errors_with_nonprimary_key(dynamo, query_data):
     # Query based on the non-primary key with no index specified
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
     with pytest.raises(ConditionCheckFailed, match=r"Index DEFAULT does not use \(\)"):
         Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"))
 
-    # Query based on the non-primary key with index
+
+def test_query_with_indexed_hash_key(dynamo, query_data):
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
     res = Model.query(Rule(f"id == {data_by_timestamp[2]['id']}"), index_name="by-id")
+    res_data = {m.name: m.dict() for m in res}
+    assert res_data == {query_data[0]["name"]: query_data[0]}
 
 
 def test_query_scan(dynamo, query_data):
-    # Query(Scan) by setting index_name=None
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
     res = Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"), index_name=None)
     res_data = {m.name: m.dict() for m in res}
     assert res_data == {d["name"]: d for d in data_by_timestamp[:2]}
 
+
+def test_query_scan_contains(dynamo, query_data):
     res = Model.query(Rule(f"'{query_data[2]['items'][1]}' in items"), index_name=None)
     res_data = {m.name: m.dict() for m in res}
     assert res_data == {query_data[2]["name"]: query_data[2]}

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -34,9 +34,7 @@ class Model(BaseModel):
         hash_key = "name"
         backend = DynamoDbBackend
         endpoint = "http://localhost:18002"
-        indexes = {
-            "by-id": ("id", )
-        }
+        indexes = {"by-id": ("id",)}
 
 
 def model_data_generator(**kwargs):
@@ -93,7 +91,7 @@ def query_data():
         yield data
     finally:
         for datum in data:
-            Model.delete(datum['name'])
+            Model.delete(datum["name"])
 
 
 def test_initialize_creates_table(dynamo):
@@ -113,7 +111,7 @@ def test_save_get_delete(dynamo):
         assert b.dict() == a.dict()
     finally:
         Model.delete(data["name"])
-    
+
     with pytest.raises(DoesNotExist, match=f'modeltitle123 "{data["name"]}" does not exist'):
         Model.get(data["name"])
 
@@ -128,14 +126,14 @@ def test_query(dynamo, query_data):
     # Query based on the non-primary key with no index specified
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    with pytest.raises(ConditionCheckFailed, match=r'Index DEFAULT does not use \(\)'):
+    with pytest.raises(ConditionCheckFailed, match=r"Index DEFAULT does not use \(\)"):
         Model.query(Rule(f"timestamp <= '{data_by_timestamp[2]['timestamp']}'"))
 
     # Query based on the non-primary key with index
     data_by_timestamp = query_data[:]
     data_by_timestamp.sort(key=lambda d: d["timestamp"])
-    res = Model.query(Rule(f"id == {data_by_timestamp[2]['id']}"), index_name='by-id')
-    
+    res = Model.query(Rule(f"id == {data_by_timestamp[2]['id']}"), index_name="by-id")
+
 
 def test_query_scan(dynamo, query_data):
     # Query(Scan) by setting index_name=None


### PR DESCRIPTION
Adds the ability to specify indexes for dynamo tables. Querying against an index requires the `index_name` parameter passed to the `query` method.

Calling `Model.initialize()` will create GSIs for specified indexes.