### PR TITLE
Handle dynamo get resource error

### DIFF
--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -318,7 +318,12 @@ class Backend:
 
     def get(self, key):
         _key = self._key_param_to_dict(key)
-        resp = self.get_table().get_item(Key=_key)
+        try:
+            resp = self.get_table().get_item(Key=_key)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                raise DoesNotExist(f'{self.table_name} "{_key}" does not exist')
+            raise e
 
         if "Item" not in resp:
             if not self.range_key:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.6"
+boto3 = "^1.17.112"
 rule-engine = "^3.2.0"
 pydantic = "^1.8.2"
 boto3 = {version = "^1.17.112", optional = true}
 dataclasses = {version = "^0.8", python = "3.6"}
 
 [tool.poetry.dev-dependencies]
-boto3 = "^1.17.112"
 pytest = "^6.2.4"
 docker = "^5.0.0"
 black = "^21.6b0"


### PR DESCRIPTION
When the table doesn't exist, it's OK to return DoesNotExist

Traceback:

```
  File "/srv/speakeasy/model/device.py", line 136, in upsert_dynamo_record
    _namespace = DyDevice.get((self.account_number, self.device_id))

  File "/srv/speakeasy/pydanticrud/pydanticrud/main.py", line 35, in get
    return cls.parse_obj(cls.__backend__.get(*args, **kwargs))

  File "/srv/speakeasy/pydanticrud/pydanticrud/backends/dynamodb.py", line 321, in get
    resp = self.get_table().get_item(Key=_key)

  File "/srv/speakeasy/lib/python3.6/site-packages/boto3/resources/factory.py", line 580, in do_action
    response = action(self, *args, **kwargs)

  File "/srv/speakeasy/lib/python3.6/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)

  File "/srv/speakeasy/lib/python3.6/site-packages/botocore/client.py", line 415, in _api_call
    return self._make_api_call(operation_name, kwargs)

  File "/srv/speakeasy/lib/python3.6/site-packages/botocore/client.py", line 745, in _make_api_call
    raise error_class(parsed_response, operation_name)

botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the GetItem operation: Requested resource not found```