### PR TITLE
Support pagination in DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ NOTE: Rule complexity is limited by the querying capabilities of the backend.
 
 ### DynamoDB
 
-`query(query_expr: Optional[Rule], filter_expr: Optional[Rule])` - Providing a
-  `query_expr` parameter will try to apply the keys of the expression to an
-  existing index. Providing a `filter_expr` parameter will filter the results of
+`query(query_expr: Optional[Rule], filter_expr: Optional[Rule], limit: Optional[str], exclusive_start_key: Optional[tuple[Any]], order: str = 'asc'`
+  - Providing a `query_expr` parameter will try to apply the keys of the expression to an
+  existing index.
+  - Providing a `filter_expr` parameter will filter the results of
   a passed `query_expr` or run a dynamodb `scan` if no `query_expr` is passed.
-  An empty call to `query()` will return the scan results (and be resource
+  - An empty call to `query()` will return the scan results (and be resource
   intensive).
+  - Providing a `limit` parameter will limit the number of results. If more results remain, the returned dataset will have an `last_evaluated_key` property that can be passed to `exclusive_start_key` to continue with the next page.
+  - Providing `order='desc'` will return the result set in descending order. This is not available for query calls that "scan" dynamodb.
 
 ## Backend Configuration Members
 

--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -295,7 +295,7 @@ class Backend:
               query_expr: Optional[Rule] = None,
               filter_expr: Optional[Rule] = None,
               limit: Optional[int] = None,
-              exclusive_start_key: Optional[Dict[str, Any]] = None,
+              exclusive_start_key: Optional[tuple[Any]] = None,
               order: str = 'asc',
               ):
         table = self.get_table()

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -256,7 +256,7 @@ def nested_query_data(nested_table):
 
 
 @pytest.fixture(scope="module")
-def nested_query_data_optional(nested_table):
+def nested_query_data_empty_ticket(nested_table):
     presets = [dict()] * 5
     data = [datum for datum in [nested_model_data_generator(include_ticket=False, **i) for i in presets]]
     for datum in data:
@@ -413,15 +413,13 @@ def test_query_scan_complex(dynamo, complex_query_data):
 
 
 def test_query_with_nested_model(dynamo, nested_query_data):
-    data_by_expires = nested_model_data_generator()
-    res = NestedModel.query(filter_expr=Rule(f"expires <= '{data_by_expires['expires']}'"))
+    res = NestedModel.query()
     res_data = [m.ticket for m in res]
     assert any(elem is not None for elem in res_data)
 
 
-def test_query_with_nested_model_optional(dynamo, nested_query_data_optional):
-    data_by_expires = nested_model_data_generator(include_ticket=False)
-    res = NestedModel.query(filter_expr=Rule(f"expires <= '{data_by_expires['expires']}'"))
+def test_query_with_nested_model_optional(dynamo, nested_query_data_empty_ticket):
+    res = NestedModel.query()
     res_data = [m.ticket for m in res]
     assert any(elem is None for elem in res_data)
 


### PR DESCRIPTION
This adds these params to the `table.query()` call for the Dynamo backend:
- order - default to 'asc' - only valid when using a dynamo `query` call (`scan` will return an error)
- limit - limit the number of records returned
- exclusive_start_key - if limit prevents all records from returning, the result object will supply a `last_evaluated_key` property to the result set. Pass that to `exclusive_start_key` to return the next "page" of results

`table.query()` now returns an `IterableResult` type that maintains the existing iterability while also providing metadata properties:
- count - count of returned records
- scanned_count - count of unfiltered records (if there was a filter_query applied)
- last_evaluated_key - if there are more records not in this dataset, this will be a tuple of the key of the last record.

