### PR TITLE
Support pagination overlaying indexes in DynamoDB

### DIFF
--- a/pydanticrud/main.py
+++ b/pydanticrud/main.py
@@ -19,6 +19,9 @@ class IterableResult:
 
         self._current_index = 0
 
+    def __len__(self):
+        return self.count
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
Followup to https://github.com/RSS-Engineering/pydanticrud/pull/10. Boto returns different results for `last_evaluated_key` based on which index is used to lookup records. This is incompatible with the previous approach. This approach returns the boto value verbatim.