### PR TITLE
Add the ability to injest a field through multiple names

### DIFF
--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -119,13 +119,14 @@ class DynamoSerializer:
     def _get_type_possibilities(self, field_name) -> Set[tuple]:
         field_properties = self.properties.get(field_name)
 
+        if not field_properties:
+            return set()
+
         possible_types = []
         if "anyOf" in field_properties:
             possible_types.extend([r.get("$ref", r) for r in field_properties["anyOf"]])
-        elif isinstance(field_properties, dict):
-            possible_types.append(field_properties.get("$ref", field_properties))
         else:
-            return set()
+            possible_types.append(field_properties.get("$ref", field_properties))
 
         def type_from_definition(definition_signature: Union[str, dict]) -> dict:
             if isinstance(definition_signature, str):

--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -117,13 +117,15 @@ class DynamoSerializer:
         self.definitions = schema.get("definitions")
 
     def _get_type_possibilities(self, field_name) -> Set[tuple]:
-        field_properties = self.properties[field_name]
+        field_properties = self.properties.get(field_name)
 
         possible_types = []
         if "anyOf" in field_properties:
             possible_types.extend([r.get("$ref", r) for r in field_properties["anyOf"]])
-        else:
+        elif isinstance(field_properties, dict):
             possible_types.append(field_properties.get("$ref", field_properties))
+        else:
+            return set()
 
         def type_from_definition(definition_signature: Union[str, dict]) -> dict:
             if isinstance(definition_signature, str):
@@ -154,6 +156,8 @@ class DynamoSerializer:
                 except (ValueError, TypeError, KeyError):
                     pass
 
+        # If we got a value that is not part of the schema, pass it
+        # through and let pydantic sort it out.
         return value
 
     def serialize_record(self, data_dict) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydanticrud"
-version = "0.2.0"
+version = "0.3.0"
 description = "Supercharge your Pydantic models with CRUD methods and a pluggable backend"
 authors = ["Timothy Farrell <tim.farrell@rackspace.com>"]
 license = "MIT"


### PR DESCRIPTION
In speakeasy we have a notification model field "namespace" but in notifications it is "namespace_id". The idea was that what is called "namespace" is truly an id and the key name should reflect that. But that's not what happened. The models diverted and the data got migrated in as Notification.namespace. The fix is to read from both and write to the correct one (rather than re-importing 2million records). This change allows that to happen.