### PR TITLE
Fix .get() By index for dynamo

### DIFF
--- a/pydanticrud/backends/dynamodb.py
+++ b/pydanticrud/backends/dynamodb.py
@@ -383,7 +383,7 @@ class Backend:
         if isinstance(key, dict):
             try:
                 return self.query(
-                    Rule(" AND ".join(f"{k} == {repr(v)}" for k, v in key.items())), limit=1
+                    Rule(" and ".join(f"{k} == {repr(v)}" for k, v in key.items())), limit=1
                 )[0]
             except IndexError:
                 raise DoesNotExist(f'{self.table_name} "{key}" does not exist')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydanticrud"
-version = "0.4.0"
+version = "0.4.1"
 description = "Supercharge your Pydantic models with CRUD methods and a pluggable backend"
 authors = ["Timothy Farrell <tim.farrell@rackspace.com>"]
 license = "MIT"

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -540,6 +540,14 @@ def test_get_simple_model_data_via_index(dynamo, simple_query_data):
     assert res.dict(by_alias=True) == simple_query_data[0]
 
 
+def test_get_complex_model_data_via_index(dynamo, complex_query_data):
+    data = complex_model_data_generator()
+    res = ComplexKeyModel.get((complex_query_data[0]['account'], complex_query_data[0]['sort_date_key']))
+    assert res.dict(by_alias=True) == complex_query_data[0]
+    res = ComplexKeyModel.get({"account": complex_query_data[0]['account'], "notification_id": complex_query_data[0]['notification_id']})
+    assert res.dict(by_alias=True) == complex_query_data[0]
+
+
 def test_alias_model_validator_ingest(dynamo):
     data = alias_model_data_generator()
     AliasKeyModel(**data)


### PR DESCRIPTION
Minor fix to Rule syntax when querying complex dynamo tables with .get()